### PR TITLE
Updated for Spark 1.2 - fails to overwrite qvalues - and other minor changes

### DIFF
--- a/dga-graphx/bin/louvain
+++ b/dga-graphx/bin/louvain
@@ -1,7 +1,7 @@
 #! /bin/bash
 
 T="$(date +%s)"
-java -cp "build/dist/*" com.soteradefense.dga.graphx.louvain.Main --jars build/dist/dga-graphx-0.1.jar,build/dist/spark-graphx_2.10-0.9.0-cdh5.0.0-beta-2.jar "$@"
+java -cp "build/dist/*" com.soteradefense.dga.graphx.louvain.Main --jars build/dist/dga-graphx-0.1.jar,build/dist/spark-graphx_2.10-1.2.0-cdh5.3.3.jar "$@"
 
 T="$(($(date +%s)-T))"
 echo "Time in seconds: ${T}"

--- a/dga-graphx/build.gradle
+++ b/dga-graphx/build.gradle
@@ -5,22 +5,22 @@ apply plugin: 'scala'
 version = '0.1'
 
 
-
 repositories {
     mavenLocal()
     mavenCentral()
     maven {
-    
-url "https://repository.cloudera.com/artifactory/cloudera-repos"
+        url "http://mvnrepository.com"
     }
-   
+    maven {
+        url "https://repository.cloudera.com/artifactory/cloudera-repos"
+    }
 }
  
 dependencies {
-    compile 'org.scala-lang:scala-library:2.10.3'
-    compile group: 'org.apache.spark', name: 'spark-core_2.10', version: '0.9.0-cdh5.0.0-beta-2'
-    compile group: 'org.apache.spark', name: 'spark-graphx_2.10', version: '0.9.0-cdh5.0.0-beta-2'
-    compile group: 'com.github.scopt', name: 'scopt_2.10', version: '3.2.0'
+    compile 'org.scala-lang:scala-library:2.10.4'
+    compile group: 'org.apache.spark', name: 'spark-core_2.10', version: '1.2.0-cdh5.3.3'
+    compile group: 'org.apache.spark', name: 'spark-graphx_2.10', version: '1.2.0-cdh5.3.3'
+    compile group: 'com.github.scopt', name: 'scopt_2.10', version: '3.3.0'
     compile(
       [group: 'org.slf4j', name: 'slf4j-api', version: '1.6.6'],
       [group: 'org.slf4j', name: 'slf4j-log4j12', version: '1.6.6']

--- a/dga-graphx/src/main/scala/com/soteradefense/dga/graphx/louvain/HDFSLouvainRunner.scala
+++ b/dga-graphx/src/main/scala/com/soteradefense/dga/graphx/louvain/HDFSLouvainRunner.scala
@@ -23,7 +23,8 @@ class HDFSLouvainRunner(minProgress:Int,progressCounter:Int,outputdir:String) ex
       println(s"qValue: $q")
         
       // overwrite the q values at each level
-      sc.parallelize(qValues, 1).saveAsTextFile(outputdir+"/qvalues")
+      // harder to overwrite in Spark 1.2 so let's write out for each level
+      sc.parallelize(qValues, 1).saveAsTextFile(outputdir+"/level_"+level+"_qvalues")
   }
   
 }

--- a/dga-graphx/src/main/scala/com/soteradefense/dga/graphx/louvain/Main.scala
+++ b/dga-graphx/src/main/scala/com/soteradefense/dga/graphx/louvain/Main.scala
@@ -4,23 +4,24 @@ import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
 import org.apache.spark.rdd.RDD
 import org.apache.spark.graphx._
-
+import org.apache.spark.storage.StorageLevel
 
 
 // specify command line options and their defaults
 case class Config(
     input:String = "",
-    output: String = "",
-    master:String="local",
-    appName:String="graphX analytic",
-    jars:String="",
-    sparkHome:String="",
+    output:String = "",
+    master:String = "local",
+    appName:String = "graphX analytic",
+    jars:String = "",
+    sparkHome:String = "",
     parallelism:Int = -1,
+    serialization:String = "MEMORY_ONLY",
     edgedelimiter:String = ",",
     minProgress:Int = 2000,
     progressCounter:Int = 1,
-    ipaddress: Boolean = false,
-    properties:Seq[(String,String)]= Seq.empty[(String,String)] )
+    ipaddress:Boolean = false,
+    properties:Seq[(String,String)] = Seq.empty[(String,String)] )
 
 
 /**
@@ -38,15 +39,16 @@ object Main {
       opt[String]('m',"master") action {(x,c)=> c.copy(master=x)} text("spark master, local[N] or spark://host:port default=local")
       opt[String]('h',"sparkhome") action {(x,c)=> c.copy(sparkHome=x)} text("SPARK_HOME Required to run on cluster")
       opt[String]('n',"jobname") action {(x,c)=> c.copy(appName=x)} text("job name")
+      opt[String]('s',"serialization") action {(x,c)=> c.copy(serialization=x)} text("data serialization")
       opt[Int]('p',"parallelism") action {(x,c)=> c.copy(parallelism=x)} text("sets spark.default.parallelism and minSplits on the edge file. default=based on input partitions")
       opt[Int]('x',"minprogress") action {(x,c)=> c.copy(minProgress=x)} text("Number of vertices that must change communites for the algorithm to consider progress. default=2000")
-       opt[Int]('y',"progresscounter") action {(x,c)=> c.copy(progressCounter=x)} text("Number of times the algorithm can fail to make progress before exiting. default=1")
+      opt[Int]('y',"progresscounter") action {(x,c)=> c.copy(progressCounter=x)} text("Number of times the algorithm can fail to make progress before exiting. default=1")
       opt[String]('d',"edgedelimiter") action {(x,c)=> c.copy(edgedelimiter=x)} text("specify input file edge delimiter. default=\",\"")
       opt[String]('j',"jars") action {(x,c)=> c.copy(jars=x)} text("comma seperated list of jars")
       opt[Boolean]('z',"ipaddress") action {(x,c)=> c.copy(ipaddress=x)} text("Set to true to convert ipaddresses to Long ids. Defaults to false")
       arg[(String,String)]("<property>=<value>....") unbounded() optional() action {case((k,v),c)=> c.copy(properties = c.properties :+ (k,v)) }
     }
-    var edgeFile, outputdir,master,jobname,jars,sparkhome ,edgedelimiter = ""
+    var edgeFile,outputdir,master,jobname,jars,sparkhome,edgedelimiter,serialization = ""
     var properties:Seq[(String,String)]= Seq.empty[(String,String)]
     var parallelism,minProgress,progressCounter = -1
     var ipaddress = false
@@ -60,6 +62,7 @@ object Main {
         sparkhome = config.sparkHome
         properties = config.properties
         parallelism = config.parallelism
+        serialization = config.serialization
         edgedelimiter = config.edgedelimiter
         minProgress = config.minProgress
         progressCounter = config.progressCounter
@@ -95,10 +98,17 @@ object Main {
 	      val tokens = row.split(edgedelimiter).map(_.trim())
 	      tokens.length match {
 	        case 2 => {new Edge(inputHashFunc(tokens(0)),inputHashFunc(tokens(1)),1L) }
-	        case 3 => {new Edge(inputHashFunc(tokens(0)),inputHashFunc(tokens(1)),tokens(2).toLong)}
+	        case 3 => {if (tokens(2).forall(_.isDigit)) {
+                              new Edge(inputHashFunc(tokens(0)),inputHashFunc(tokens(1)),tokens(2).toLong)
+                           } else {
+                              new Edge(inputHashFunc(tokens(0)),inputHashFunc(tokens(1)),1L)
+                           }
+                          }
 	        case _ => {throw new IllegalArgumentException("invalid input line: "+row)}
 	      }
 	   })	   
+
+    edgeRDD.persist(StorageLevel.fromString(serialization));
 	
 	// if the parallelism option was set map the input to the correct number of partitions,
 	// otherwise parallelism will be based off number of HDFS blocks


### PR DESCRIPTION
Updated for Spark 1.2 as bundled with Cloudera 5.3.3 and fixed issue with saveAsTextFile failing to overwrite qvalues - now saving each level's qvalues separately. Also changed to allow parsing input with the third column being non-numeric (ignores). Added option to specify serialization.
